### PR TITLE
fix the doctype

### DIFF
--- a/bin/engines/vue.js
+++ b/bin/engines/vue.js
@@ -29,7 +29,7 @@ module.exports = function(filePath) {
 
     convertTemplate() {
       html = pug
-        .render(findTemplate(), { pretty: true })
+        .render(findTemplate(), { pretty: true, doctype: 'html' })
         .replace(new RegExp('v-else="v-else"', `g`), "v-else")
         .replace(new RegExp("&gt;", `g`), ">")
         .replace(new RegExp("&amp;", `g`), "&")


### PR DESCRIPTION
In html, there are non-value attributes such as below:

```
// pug
div(
  hoge
)

// html
<div hoge />
```

However, by default, the pug renderer renders the HTML in a somewhat different way:

```
// pug
div(
  hoge
)

// html
<div hoge="hoge" />
```

Thus, I fixed the option passing to the `pug.renderer` function, to make the non-value attributes rendered properly.

```ts
pug.render(findTemplate(), { pretty: true, doctype: 'html' })
```